### PR TITLE
[1.20 Forge] Improve PanicGoalMixin performance

### DIFF
--- a/src/main/java/com/rosemods/windswept/common/block/CarvedPineconeBlock.java
+++ b/src/main/java/com/rosemods/windswept/common/block/CarvedPineconeBlock.java
@@ -1,6 +1,10 @@
 package com.rosemods.windswept.common.block;
 
+import com.rosemods.windswept.common.block_entity.CarvedPineconeBlockEntity;
+import com.rosemods.windswept.common.block_entity.FearfulBlockEntity;
+import com.rosemods.windswept.common.block_entity.WillOTheWispBlockEntity;
 import com.rosemods.windswept.core.other.tags.WindsweptBlockTags;
+import com.rosemods.windswept.core.registry.WindsweptBlockEntities;
 import com.rosemods.windswept.core.registry.WindsweptSounds;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -13,13 +17,19 @@ import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.BaseEntityBlock;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.HorizontalDirectionalBlock;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityTicker;
+import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.phys.BlockHitResult;
+import org.jetbrains.annotations.Nullable;
 
-public class CarvedPineconeBlock extends HorizontalDirectionalBlock {
+public class CarvedPineconeBlock extends HorizontalDirectionalBlock implements EntityBlock {
     private static final int[] KEY = new int[]{0, 3, 5, 10, 14, 15, 21, 22};
 
     public CarvedPineconeBlock(Properties properties) {
@@ -79,4 +89,13 @@ public class CarvedPineconeBlock extends HorizontalDirectionalBlock {
         builder.add(FACING);
     }
 
+    @Override
+    public @Nullable BlockEntity newBlockEntity(BlockPos pos, BlockState state) {
+        return new CarvedPineconeBlockEntity(pos, state);
+    }
+
+    @Override
+    public <T extends BlockEntity> BlockEntityTicker<T> getTicker(Level level, BlockState state, BlockEntityType<T> type) {
+        return !level.isClientSide ? BaseEntityBlock.createTickerHelper(type, WindsweptBlockEntities.CARVED_PINECONE.get(), FearfulBlockEntity::tick) : null;
+    }
 }

--- a/src/main/java/com/rosemods/windswept/common/block_entity/CarvedPineconeBlockEntity.java
+++ b/src/main/java/com/rosemods/windswept/common/block_entity/CarvedPineconeBlockEntity.java
@@ -1,0 +1,11 @@
+package com.rosemods.windswept.common.block_entity;
+
+import com.rosemods.windswept.core.registry.WindsweptBlockEntities;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.state.BlockState;
+
+public class CarvedPineconeBlockEntity extends FearfulBlockEntity {
+  public CarvedPineconeBlockEntity(BlockPos pos, BlockState state) {
+    super(WindsweptBlockEntities.CARVED_PINECONE.get(), pos, state);
+  }
+}

--- a/src/main/java/com/rosemods/windswept/common/block_entity/FearfulBlockEntity.java
+++ b/src/main/java/com/rosemods/windswept/common/block_entity/FearfulBlockEntity.java
@@ -14,7 +14,7 @@ public abstract class FearfulBlockEntity extends BlockEntity {
 
     public FearfulBlockEntity(BlockEntityType<?> type, BlockPos pos, BlockState state) {
         super(type, pos, state);
-        this.radius = new AABB(pos).inflate(2);
+        this.radius = new AABB(pos).inflate(PathfinderMobData.BLOCK_RADIUS);
     }
 
     public static void tick(Level level, BlockPos pos, BlockState state, FearfulBlockEntity blockEntity) {

--- a/src/main/java/com/rosemods/windswept/common/block_entity/FearfulBlockEntity.java
+++ b/src/main/java/com/rosemods/windswept/common/block_entity/FearfulBlockEntity.java
@@ -1,0 +1,24 @@
+package com.rosemods.windswept.common.block_entity;
+
+import com.rosemods.windswept.common.entity.PathfinderMobData;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.PathfinderMob;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.AABB;
+
+public abstract class FearfulBlockEntity extends BlockEntity {
+    private final AABB radius;
+
+    public FearfulBlockEntity(BlockEntityType<?> type, BlockPos pos, BlockState state) {
+        super(type, pos, state);
+        this.radius = new AABB(pos).inflate(2);
+    }
+
+    public static void tick(Level level, BlockPos pos, BlockState state, FearfulBlockEntity blockEntity) {
+        for (PathfinderMob entity : level.getEntitiesOfClass(PathfinderMob.class, blockEntity.radius))
+            ((PathfinderMobData) entity).windswept$setPanicPosition(pos);
+    }
+}

--- a/src/main/java/com/rosemods/windswept/common/block_entity/WillOTheWispBlockEntity.java
+++ b/src/main/java/com/rosemods/windswept/common/block_entity/WillOTheWispBlockEntity.java
@@ -1,10 +1,12 @@
 package com.rosemods.windswept.common.block_entity;
 
 import com.rosemods.windswept.common.block.WillOTheWispBlock;
+import com.rosemods.windswept.common.entity.PathfinderMobData;
 import com.rosemods.windswept.core.registry.WindsweptBlockEntities;
 import com.rosemods.windswept.core.registry.WindsweptBlocks;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.world.entity.PathfinderMob;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.HorizontalDirectionalBlock;
@@ -13,11 +15,17 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
 
 public class WillOTheWispBlockEntity extends BlockEntity {
+    private final AABB radius;
+
     public WillOTheWispBlockEntity(BlockPos pos, BlockState state) {
         super(WindsweptBlockEntities.WILL_O_THE_WISP.get(), pos, state);
+        this.radius = new AABB(pos).inflate(2);
     }
 
     public static void tick(Level level, BlockPos pos, BlockState state, WillOTheWispBlockEntity blockEntity) {
+        for (PathfinderMob entity : level.getEntitiesOfClass(PathfinderMob.class, blockEntity.radius))
+            ((PathfinderMobData) entity).windswept$setPanicPosition(pos);
+
         for (Direction direction : Direction.Plane.HORIZONTAL)
             if (state.getValue(HorizontalDirectionalBlock.FACING) != direction && level.getBlockState(pos.relative(direction)).isAir())
                 for (Player player : level.getEntitiesOfClass(Player.class, expandTowards(new AABB(pos.relative(direction)), direction, 6)))
@@ -25,6 +33,8 @@ public class WillOTheWispBlockEntity extends BlockEntity {
                         turn(level, pos, state, direction, player);
                         return;
                     }
+
+
     }
 
     private static void turn(Level level, BlockPos pos, BlockState state, Direction direction, Player player) {

--- a/src/main/java/com/rosemods/windswept/common/block_entity/WillOTheWispBlockEntity.java
+++ b/src/main/java/com/rosemods/windswept/common/block_entity/WillOTheWispBlockEntity.java
@@ -14,17 +14,13 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
 
-public class WillOTheWispBlockEntity extends BlockEntity {
-    private final AABB radius;
-
+public class WillOTheWispBlockEntity extends FearfulBlockEntity {
     public WillOTheWispBlockEntity(BlockPos pos, BlockState state) {
         super(WindsweptBlockEntities.WILL_O_THE_WISP.get(), pos, state);
-        this.radius = new AABB(pos).inflate(2);
     }
 
     public static void tick(Level level, BlockPos pos, BlockState state, WillOTheWispBlockEntity blockEntity) {
-        for (PathfinderMob entity : level.getEntitiesOfClass(PathfinderMob.class, blockEntity.radius))
-            ((PathfinderMobData) entity).windswept$setPanicPosition(pos);
+        FearfulBlockEntity.tick(level, pos, state, blockEntity);
 
         for (Direction direction : Direction.Plane.HORIZONTAL)
             if (state.getValue(HorizontalDirectionalBlock.FACING) != direction && level.getBlockState(pos.relative(direction)).isAir())

--- a/src/main/java/com/rosemods/windswept/common/entity/PathfinderMobData.java
+++ b/src/main/java/com/rosemods/windswept/common/entity/PathfinderMobData.java
@@ -6,4 +6,7 @@ import org.jetbrains.annotations.Nullable;
 public interface PathfinderMobData {
   @Nullable BlockPos windswept$getPanicPosition ();
   void windswept$setPanicPosition (@Nullable BlockPos pos);
+
+  int BLOCK_RADIUS = 2;
+  double BLOCK_RADIUS_SQUARE = BLOCK_RADIUS * BLOCK_RADIUS;
 }

--- a/src/main/java/com/rosemods/windswept/common/entity/PathfinderMobData.java
+++ b/src/main/java/com/rosemods/windswept/common/entity/PathfinderMobData.java
@@ -1,0 +1,9 @@
+package com.rosemods.windswept.common.entity;
+
+import net.minecraft.core.BlockPos;
+import org.jetbrains.annotations.Nullable;
+
+public interface PathfinderMobData {
+  @Nullable BlockPos windswept$getPanicPosition ();
+  void windswept$setPanicPosition (@Nullable BlockPos pos);
+}

--- a/src/main/java/com/rosemods/windswept/core/mixin/PanicGoalMixin.java
+++ b/src/main/java/com/rosemods/windswept/core/mixin/PanicGoalMixin.java
@@ -25,7 +25,23 @@ public class PanicGoalMixin {
 
     @Inject(method = "canUse", at = @At("HEAD"), cancellable = true)
     private void canUse(CallbackInfoReturnable<Boolean> info) {
-        AABB radius = new AABB(this.mob.blockPosition()).inflate(2);
+        PathfinderMobData mobData = (PathfinderMobData) this.mob;
+        BlockPos panicPos = mobData.windswept$getPanicPosition();
+        if (panicPos != null) {
+            if (this.mob.distanceToSqr(panicPos.getX(), panicPos.getY(), panicPos.getZ()) < PathfinderMobData.BLOCK_RADIUS_SQUARE) {
+                mobData.windswept$setPanicPosition(null);
+            } else {
+                BlockState state = this.mob.level().getBlockState(panicPos);
+                if (state.is(WindsweptBlocks.CARVED_PINECONE_BLOCK.get()) || state.is(WindsweptBlocks.WILL_O_THE_WISP.get())) {
+                    info.setReturnValue(true);
+                    return;
+                } else {
+                    mobData.windswept$setPanicPosition(null);
+                }
+            }
+        }
+
+        AABB radius = new AABB(this.mob.blockPosition()).inflate(PathfinderMobData.BLOCK_RADIUS);
 
         for (LivingEntity entity : this.mob.level().getEntitiesOfClass(LivingEntity.class, radius))
             if (this.mob != entity && (entity.getItemBySlot(EquipmentSlot.HEAD)
@@ -34,21 +50,6 @@ public class PanicGoalMixin {
                 info.setReturnValue(true);
                 return;
             }
-
-        PathfinderMobData mobData = (PathfinderMobData) this.mob;
-        BlockPos panicPos = mobData.windswept$getPanicPosition();
-        if (panicPos != null) {
-            if (this.mob.distanceToSqr(panicPos.getX(), panicPos.getY(), panicPos.getZ()) < PathfinderMobData.BLOCK_RADIUS_SQUARE) {
-                mobData.windswept$setPanicPosition(null);
-                return;
-            }
-            BlockState state = this.mob.level().getBlockState(panicPos);
-            if (state.is(WindsweptBlocks.CARVED_PINECONE_BLOCK.get()) || state.is(WindsweptBlocks.WILL_O_THE_WISP.get())) {
-                info.setReturnValue(true);
-            } else {
-                mobData.windswept$setPanicPosition(null);
-            }
-        }
     }
 
 }

--- a/src/main/java/com/rosemods/windswept/core/mixin/PanicGoalMixin.java
+++ b/src/main/java/com/rosemods/windswept/core/mixin/PanicGoalMixin.java
@@ -1,7 +1,9 @@
 package com.rosemods.windswept.core.mixin;
 
+import com.rosemods.windswept.common.entity.PathfinderMobData;
 import com.rosemods.windswept.common.entity.Frostbiter;
 import com.rosemods.windswept.core.registry.WindsweptBlocks;
+import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.PathfinderMob;
@@ -26,16 +28,27 @@ public class PanicGoalMixin {
         AABB radius = new AABB(this.mob.blockPosition()).inflate(2);
 
         for (LivingEntity entity : this.mob.level().getEntitiesOfClass(LivingEntity.class, radius))
-            if (this.mob != entity && (entity.getItemBySlot(EquipmentSlot.HEAD).is(WindsweptBlocks.CARVED_PINECONE_BLOCK.get().asItem()) || (entity instanceof Frostbiter frostbiter && frostbiter.hasControllingPassenger()))) {
+            if (this.mob != entity && (entity.getItemBySlot(EquipmentSlot.HEAD)
+                .is(WindsweptBlocks.CARVED_PINECONE_BLOCK.get()
+                    .asItem()) || (entity instanceof Frostbiter frostbiter && frostbiter.hasControllingPassenger()))) {
                 info.setReturnValue(true);
                 return;
             }
 
-        for (BlockState state : this.mob.level().getBlockStatesIfLoaded(radius).toList())
-            if (state.is(WindsweptBlocks.CARVED_PINECONE_BLOCK.get()) || state.is(WindsweptBlocks.WILL_O_THE_WISP.get())) {
-                info.setReturnValue(true);
+        PathfinderMobData mobData = (PathfinderMobData) this.mob;
+        BlockPos panicPos = mobData.windswept$getPanicPosition();
+        if (panicPos != null) {
+            if (this.mob.distanceToSqr(panicPos.getX(), panicPos.getY(), panicPos.getZ()) < 4.0d) {
+                mobData.windswept$setPanicPosition(null);
                 return;
             }
+            BlockState state = this.mob.level().getBlockState(panicPos);
+            if (state.is(WindsweptBlocks.CARVED_PINECONE_BLOCK.get()) || state.is(WindsweptBlocks.WILL_O_THE_WISP.get())) {
+                info.setReturnValue(true);
+            } else {
+                mobData.windswept$setPanicPosition(null);
+            }
+        }
     }
 
 }

--- a/src/main/java/com/rosemods/windswept/core/mixin/PanicGoalMixin.java
+++ b/src/main/java/com/rosemods/windswept/core/mixin/PanicGoalMixin.java
@@ -38,7 +38,7 @@ public class PanicGoalMixin {
         PathfinderMobData mobData = (PathfinderMobData) this.mob;
         BlockPos panicPos = mobData.windswept$getPanicPosition();
         if (panicPos != null) {
-            if (this.mob.distanceToSqr(panicPos.getX(), panicPos.getY(), panicPos.getZ()) < 4.0d) {
+            if (this.mob.distanceToSqr(panicPos.getX(), panicPos.getY(), panicPos.getZ()) < PathfinderMobData.BLOCK_RADIUS_SQUARE) {
                 mobData.windswept$setPanicPosition(null);
                 return;
             }

--- a/src/main/java/com/rosemods/windswept/core/mixin/PathfinderMobMixin.java
+++ b/src/main/java/com/rosemods/windswept/core/mixin/PathfinderMobMixin.java
@@ -1,0 +1,24 @@
+package com.rosemods.windswept.core.mixin;
+
+import com.rosemods.windswept.common.entity.PathfinderMobData;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.PathfinderMob;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+
+@Mixin(PathfinderMob.class)
+public class PathfinderMobMixin implements PathfinderMobData {
+  @Unique
+  private @Nullable BlockPos windswept$potentialScarePosition = null;
+
+  @Override
+  public @Nullable BlockPos windswept$getPanicPosition() {
+    return windswept$potentialScarePosition;
+  }
+
+  @Override
+  public void windswept$setPanicPosition(@Nullable BlockPos pos) {
+    this.windswept$potentialScarePosition = pos;
+  }
+}

--- a/src/main/java/com/rosemods/windswept/core/registry/WindsweptBlockEntities.java
+++ b/src/main/java/com/rosemods/windswept/core/registry/WindsweptBlockEntities.java
@@ -1,8 +1,6 @@
 package com.rosemods.windswept.core.registry;
 
-import com.rosemods.windswept.common.block_entity.NightFairyLightBlockEntity;
-import com.rosemods.windswept.common.block_entity.SuspiciousSnowBlockEntity;
-import com.rosemods.windswept.common.block_entity.WillOTheWispBlockEntity;
+import com.rosemods.windswept.common.block_entity.*;
 import com.rosemods.windswept.core.Windswept;
 import com.teamabnormals.blueprint.core.util.registry.BlockEntitySubRegistryHelper;
 import net.minecraft.world.level.block.entity.BlockEntityType;
@@ -18,6 +16,7 @@ public class WindsweptBlockEntities {
     public static final RegistryObject<BlockEntityType<WillOTheWispBlockEntity>> WILL_O_THE_WISP = HELPER.createBlockEntity("will_o_the_wisp", WillOTheWispBlockEntity::new, () -> Set.of(WindsweptBlocks.WILL_O_THE_WISP.get()));
     public static final RegistryObject<BlockEntityType<NightFairyLightBlockEntity>> NIGHT_FAIRY_LIGHT = HELPER.createBlockEntity("night_fairy_light", NightFairyLightBlockEntity::new, () -> Set.of(WindsweptBlocks.NIGHT_FAIRY_LIGHT.get()));
     public static final RegistryObject<BlockEntityType<SuspiciousSnowBlockEntity>> SUSPICIOUS_SNOW = HELPER.createBlockEntity("suspicious_snow", SuspiciousSnowBlockEntity::new, () -> Set.of(WindsweptBlocks.SUSPICIOUS_SNOW.get()));
+    public static final RegistryObject<BlockEntityType<CarvedPineconeBlockEntity>> CARVED_PINECONE = HELPER.createBlockEntity("fearful_block", CarvedPineconeBlockEntity::new, () -> Set.of(WindsweptBlocks.CARVED_PINECONE_BLOCK.get()));
 
 }
 

--- a/src/main/resources/windswept.mixins.json
+++ b/src/main/resources/windswept.mixins.json
@@ -20,6 +20,7 @@
     "LlamaMixin",
     "MossBlockMixin",
     "PanicGoalMixin",
+    "PathfinderMobMixin",
     "PlayerMixin",
     "PowderSnowBlockMixin",
     "SheepMixin",


### PR DESCRIPTION
Iterating over block states can be extremely expensive, especially when the number of `PathfinderMob`s with `PanicGoal`s are activating on the server.

I noticed that this was causing significant degradation to server TPS. 

This PR shifts the logic from the `PanicGoal` into the `WillOTheWispBlockEntity` and the newly created `CarvedPineBlockEntity` and results in a *significant* improvement in performance.

I've been testing this version of Windswept on the same server and have yet to run into any issues with it.