### PR TITLE
publish snapshots to registry.somethingcatchy.net

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,3 +95,28 @@ idea {
         downloadJavadoc = true
     }
 }
+
+publishing {
+    repositories {
+        mavenLocal()
+        def NEXUS_USER = System.getenv("NEXUS_USER")
+        def NEXUS_TOKEN = System.getenv("NEXUS_TOKEN")
+        if (NEXUS_USER != null && NEXUS_TOKEN != null) {
+            maven {
+                url = uri("https://registry.somethingcatchy.net/repository/maven-snapshots/")
+                credentials {
+                    username = NEXUS_USER
+                    password = NEXUS_TOKEN
+                }
+            }
+        }
+    }
+
+    publications {
+        maven(MavenPublication) {
+            from components.java
+            version = "${project.mod_version}-SNAPSHOT"
+            artifactId = "windswept-${project.mc_version}"
+        }
+    }
+}


### PR DESCRIPTION
With this, running `./gradlew publish` will publish a new snapshot version to the galena maven repository, specifically the one for snapshots.
There is also one for releases, which does not allow the same version tag to be published twice and should only be used as part of some automatic release process.
The snapshot repository only allows versions ending in `-SNAPSHOT`, but those can be overwritten by just publishing with the same version again. I use snapshots as a work-in-progress state of an upcoming version, that developers can already integrate in their gradle setup, without the final version being releases on modrinth yet.

To actually publish to the registry you of course need to be authenticated, I would create a new user for you that has the permission to publish under `com.rosemods` for that, that you then just have to set as your environment variable

Some of the galena projects that use my automatic release setup (for example oreganized & nirvana) also use github actions to just always publish a new snapshot version there every time something is pushed to a main branch ([see here](https://registry.somethingcatchy.net/#browse/browse:maven-snapshots:dev%2Fgalena%2Foreganized%2F5.2.0-SNAPSHOT))
I could also write you the required github actions pipeline if you're interested in that.